### PR TITLE
Add Google Calendar sync for bookings with admin calendar view

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -17,7 +17,9 @@ function wressla_register_settings(){
             'location' => 'Wrocław, Polska',
             'google_client_id' => '',
             'facebook_app_id' => '',
-            'facebook_app_secret' => ''
+            'facebook_app_secret' => '',
+            'google_calendar_id' => '',
+            'google_service_account_json' => ''
         ]
     ]);
 }
@@ -31,6 +33,8 @@ function wressla_sanitize_options($opts){
     $opts['google_client_id'] = sanitize_text_field($opts['google_client_id'] ?? '');
     $opts['facebook_app_id'] = sanitize_text_field($opts['facebook_app_id'] ?? '');
     $opts['facebook_app_secret'] = sanitize_text_field($opts['facebook_app_secret'] ?? '');
+    $opts['google_calendar_id'] = sanitize_text_field($opts['google_calendar_id'] ?? '');
+    $opts['google_service_account_json'] = $opts['google_service_account_json'] ?? '';
     return $opts;
 }
 
@@ -51,6 +55,8 @@ function wressla_settings_page(){
                 <tr><th colspan="2"><h2>Kalendarz</h2></th></tr>
                 <tr><th>Strefa czasowa</th><td><input type="text" name="wressla_core_options[tz]" value="<?php echo esc_attr($opts['tz'] ?? 'Europe/Warsaw'); ?>"></td></tr>
                 <tr><th>Lokalizacja (mapa/spotkanie)</th><td><input type="text" name="wressla_core_options[location]" value="<?php echo esc_attr($opts['location'] ?? 'Wrocław, Polska'); ?>" size="60"></td></tr>
+                <tr><th>Google Calendar ID</th><td><input type="text" name="wressla_core_options[google_calendar_id]" value="<?php echo esc_attr($opts['google_calendar_id'] ?? ''); ?>" size="60"></td></tr>
+                <tr><th>Google Service Account JSON</th><td><textarea name="wressla_core_options[google_service_account_json]" rows="5" cols="60"><?php echo esc_textarea($opts['google_service_account_json'] ?? ''); ?></textarea></td></tr>
                 <tr><td colspan="2">
                     <p><strong>Subskrypcja ICS (Google Calendar → From URL):</strong><br>
                     Rezerwacje: <code><?php echo esc_html( home_url('/?wressla_ics=1') ); ?></code><br>

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -201,6 +201,10 @@ function wressla_submit_booking() {
     $attachments = $ics_path ? [$ics_path] : [];
     wp_mail( $admin, 'Wressla – Nowa rezerwacja', $body, [], $attachments );
 
+    if ( function_exists('wressla_insert_booking_to_gcal') ){
+        wressla_insert_booking_to_gcal( $post_id );
+    }
+
     wp_send_json_success([
         'message' => __('Rezerwacja zapisana. Skontaktujemy się w celu potwierdzenia.', 'wressla-core'),
         'gcal'    => $gcal,


### PR DESCRIPTION
## Summary
- sync new bookings to Google Calendar via service account
- expose calendar ID and service account fields in settings
- add admin page embedding Google Calendar with all reservations

## Testing
- `php -l includes/calendar.php`
- `php -l includes/settings.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a65a17244c832084d993ad42373479