### PR TITLE
Allow configuring Google Calendar ID

### DIFF
--- a/assets/gcal-auth.js
+++ b/assets/gcal-auth.js
@@ -62,9 +62,12 @@
                               + '&token=' + encodeURIComponent(token.access_token),
                     });
                     const signout = document.getElementById('signout_button');
-                    if (signout) signout.style.display = 'inline-block';
+                    if (signout){
+                        signout.style.display = 'inline-block';
+                        if (wresslaGCal.signOutText) signout.innerText = wresslaGCal.signOutText;
+                    }
                     const authorize = document.getElementById('authorize_button');
-                    if (authorize) authorize.innerText = 'Refresh';
+                    if (authorize) authorize.innerText = wresslaGCal.refreshText || 'Refresh';
                 }catch(e){
                     console.error('Token save failed', e);
                 }
@@ -91,9 +94,12 @@
         }
         gapi.client.setToken(null);
         const authorize = document.getElementById('authorize_button');
-        if (authorize) authorize.innerText = 'Authorize';
+        if (authorize) authorize.innerText = wresslaGCal.authorizeText || 'Authorize';
         const signout = document.getElementById('signout_button');
-        if (signout) signout.style.display = 'none';
+        if (signout){
+            signout.style.display = 'none';
+            if (wresslaGCal.signOutText) signout.innerText = wresslaGCal.signOutText;
+        }
         const content = document.getElementById('content');
         if (content) content.textContent = '';
     };
@@ -111,13 +117,13 @@
         const content = document.getElementById('content');
         if (!content) return;
         if (!events || !events.length){
-            content.textContent = 'No events found.';
+            content.textContent = wresslaGCal.noEventsText || 'No events found.';
             return;
         }
-        let out = 'Events:\n';
+        let out = (wresslaGCal.eventsLabel || 'Events:') + '\n';
         for (const ev of events){
             const when = ev.start.dateTime || ev.start.date || '';
-            out += `${ev.summary || '(no title)'} (${when})\n`;
+            out += `${ev.summary || wresslaGCal.noTitleText || '(no title)'} (${when})\n`;
         }
         content.textContent = out;
     }

--- a/assets/gcal-auth.js
+++ b/assets/gcal-auth.js
@@ -98,15 +98,15 @@
         if (content) content.textContent = '';
     };
 
-    async function listUpcomingEvents(){
-        const resp = await gapi.client.calendar.events.list({
-            calendarId: 'primary',
-            timeMin: (new Date()).toISOString(),
-            showDeleted: false,
-            singleEvents: true,
-            maxResults: 5,
-            orderBy: 'startTime',
-        });
+     async function listUpcomingEvents(){
+         const resp = await gapi.client.calendar.events.list({
+             calendarId: wresslaGCal.calendarId || 'primary',
+             timeMin: (new Date()).toISOString(),
+             showDeleted: false,
+             singleEvents: true,
+             maxResults: 5,
+             orderBy: 'startTime',
+         });
         const events = resp && resp.result ? resp.result.items : [];
         const content = document.getElementById('content');
         if (!content) return;

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -34,7 +34,7 @@ function wressla_gcal_admin_scripts( $hook ){
     $api_key   = sanitize_text_field( $opts['gcal_api_key'] ?? '' );
     $calendar_id = sanitize_text_field( $opts['gcal_calendar_id'] ?? '' );
     if ( empty( $client_id ) || empty( $api_key ) ) return;
-    wp_enqueue_script( 'wressla-gcal-auth', WRESSLA_CORE_URL . 'assets/gcal-auth.js', [], WRESSLA_CORE_VER, true );
+    wp_enqueue_script( 'wressla-gcal-auth', WRESSLA_CORE_URL . 'assets/gcal-auth.js', [], WRESSLA_CORE_VER, false );
     wp_localize_script( 'wressla-gcal-auth', 'wresslaGCal', [
         'clientId'     => $client_id,
         'apiKey'       => $api_key,

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -32,11 +32,13 @@ function wressla_gcal_admin_scripts( $hook ){
     $opts = get_option('wressla_core_options',[]);
     $client_id = sanitize_text_field( $opts['gcal_client_id'] ?? '' );
     $api_key   = sanitize_text_field( $opts['gcal_api_key'] ?? '' );
+    $calendar_id = sanitize_text_field( $opts['gcal_calendar_id'] ?? '' );
     if ( empty( $client_id ) || empty( $api_key ) ) return;
     wp_enqueue_script( 'wressla-gcal-auth', WRESSLA_CORE_URL . 'assets/gcal-auth.js', [], WRESSLA_CORE_VER, true );
     wp_localize_script( 'wressla-gcal-auth', 'wresslaGCal', [
         'clientId' => $client_id,
         'apiKey'   => $api_key,
+        'calendarId' => $calendar_id,
         'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
         'nonce'    => wp_create_nonce( 'wressla_gcal' ),
     ] );
@@ -56,7 +58,8 @@ function wressla_register_settings(){
             'facebook_app_id' => '',
             'facebook_app_secret' => '',
             'gcal_api_key' => '',
-            'gcal_client_id' => ''
+            'gcal_client_id' => '',
+            'gcal_calendar_id' => ''
         ]
     ]);
 }
@@ -72,10 +75,11 @@ function wressla_sanitize_options($opts){
     $opts['facebook_app_secret'] = sanitize_text_field($opts['facebook_app_secret'] ?? '');
     $opts['gcal_api_key'] = sanitize_text_field($opts['gcal_api_key'] ?? '');
     $opts['gcal_client_id'] = sanitize_text_field($opts['gcal_client_id'] ?? '');
+    $opts['gcal_calendar_id'] = sanitize_text_field($opts['gcal_calendar_id'] ?? '');
 
     if ( ! empty( $opts['gcal_api_key'] ) && ! empty( $opts['gcal_client_id'] ) && function_exists( 'wressla_gcal_check_connection' ) ) {
-        $check = wressla_gcal_check_connection( $opts['gcal_api_key'], $opts['gcal_client_id'] );
-        $cache_key = 'wressla_gcal_conn_' . md5( $opts['gcal_api_key'] . '|' . $opts['gcal_client_id'] );
+        $check = wressla_gcal_check_connection( $opts['gcal_api_key'], $opts['gcal_client_id'], $opts['gcal_calendar_id'] );
+        $cache_key = 'wressla_gcal_conn_' . md5( $opts['gcal_api_key'] . '|' . $opts['gcal_client_id'] . '|' . $opts['gcal_calendar_id'] );
         set_transient( $cache_key, $check, 10 * MINUTE_IN_SECONDS );
         if ( is_wp_error( $check ) ) {
             add_settings_error( 'wressla_core_options', 'gcal', sprintf( __( 'Błąd połączenia z Google Calendar: %s', 'wressla-core' ), $check->get_error_message() ), 'error' );
@@ -107,6 +111,7 @@ function wressla_settings_page(){
                 <tr><th>Lokalizacja (mapa/spotkanie)</th><td><input type="text" name="wressla_core_options[location]" value="<?php echo esc_attr($opts['location'] ?? 'Wrocław, Polska'); ?>" size="60"></td></tr>
                 <tr><th>Google Calendar API Key</th><td><input type="text" name="wressla_core_options[gcal_api_key]" value="<?php echo esc_attr($opts['gcal_api_key'] ?? ''); ?>" size="60"></td></tr>
                 <tr><th>Google Calendar Client ID</th><td><input type="text" name="wressla_core_options[gcal_client_id]" value="<?php echo esc_attr($opts['gcal_client_id'] ?? ''); ?>" size="60"></td></tr>
+                <tr><th>Google Calendar ID</th><td><input type="text" name="wressla_core_options[gcal_calendar_id]" value="<?php echo esc_attr($opts['gcal_calendar_id'] ?? ''); ?>" size="60"></td></tr>
                 <?php if ( ! empty( $opts['gcal_api_key'] ) && ! empty( $opts['gcal_client_id'] ) ) : ?>
                 <tr><th><?php esc_html_e( 'Autoryzacja', 'wressla-core' ); ?></th><td>
                     <button id="authorize_button" class="button" onclick="handleAuthClick()" disabled>Authorize</button>

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -15,8 +15,8 @@ function wressla_bookings_calendar_page(){
     echo '<div class="wrap"><h1>' . esc_html__( 'Kalendarz rezerwacji', 'wressla-core' ) . '</h1>';
     if ( $client_id && $api_key ) {
         echo '<p>' . esc_html__( 'Autoryzuj dostęp do kalendarza Google, aby zobaczyć rezerwacje.', 'wressla-core' ) . '</p>';
-        echo '<button id="authorize_button" class="button" onclick="handleAuthClick()" disabled>Authorize</button> ';
-        echo '<button id="signout_button" class="button" onclick="handleSignoutClick()" style="display:none">Sign Out</button>';
+        echo '<button id="authorize_button" class="button" onclick="handleAuthClick()" disabled>' . esc_html__( 'Autoryzuj', 'wressla-core' ) . '</button> ';
+        echo '<button id="signout_button" class="button" onclick="handleSignoutClick()" style="display:none">' . esc_html__( 'Wyloguj', 'wressla-core' ) . '</button>';
         echo '<pre id="content" style="white-space:pre-wrap;"></pre>';
         echo '<script async defer src="https://apis.google.com/js/api.js" onload="gapiLoaded()"></script>';
         echo '<script async defer src="https://accounts.google.com/gsi/client" onload="gisLoaded()"></script>';
@@ -36,11 +36,17 @@ function wressla_gcal_admin_scripts( $hook ){
     if ( empty( $client_id ) || empty( $api_key ) ) return;
     wp_enqueue_script( 'wressla-gcal-auth', WRESSLA_CORE_URL . 'assets/gcal-auth.js', [], WRESSLA_CORE_VER, true );
     wp_localize_script( 'wressla-gcal-auth', 'wresslaGCal', [
-        'clientId' => $client_id,
-        'apiKey'   => $api_key,
-        'calendarId' => $calendar_id,
-        'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
-        'nonce'    => wp_create_nonce( 'wressla_gcal' ),
+        'clientId'     => $client_id,
+        'apiKey'       => $api_key,
+        'calendarId'   => $calendar_id,
+        'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+        'nonce'        => wp_create_nonce( 'wressla_gcal' ),
+        'authorizeText'=> __( 'Autoryzuj', 'wressla-core' ),
+        'refreshText'  => __( 'Odśwież', 'wressla-core' ),
+        'signOutText'  => __( 'Wyloguj', 'wressla-core' ),
+        'eventsLabel'  => __( 'Wydarzenia:', 'wressla-core' ),
+        'noEventsText' => __( 'Brak wydarzeń.', 'wressla-core' ),
+        'noTitleText'  => __( '(brak tytułu)', 'wressla-core' ),
     ] );
 }
 add_action( 'admin_enqueue_scripts', 'wressla_gcal_admin_scripts' );
@@ -114,8 +120,8 @@ function wressla_settings_page(){
                 <tr><th>Google Calendar ID</th><td><input type="text" name="wressla_core_options[gcal_calendar_id]" value="<?php echo esc_attr($opts['gcal_calendar_id'] ?? ''); ?>" size="60"></td></tr>
                 <?php if ( ! empty( $opts['gcal_api_key'] ) && ! empty( $opts['gcal_client_id'] ) ) : ?>
                 <tr><th><?php esc_html_e( 'Autoryzacja', 'wressla-core' ); ?></th><td>
-                    <button id="authorize_button" class="button" onclick="handleAuthClick()" disabled>Authorize</button>
-                    <button id="signout_button" class="button" onclick="handleSignoutClick()" style="display:none">Sign Out</button>
+                    <button id="authorize_button" class="button" onclick="handleAuthClick()" disabled><?php esc_html_e( 'Autoryzuj', 'wressla-core' ); ?></button>
+                    <button id="signout_button" class="button" onclick="handleSignoutClick()" style="display:none"><?php esc_html_e( 'Wyloguj', 'wressla-core' ); ?></button>
                     <pre id="content" style="white-space:pre-wrap;"></pre>
                     <script async defer src="https://apis.google.com/js/api.js" onload="gapiLoaded()"></script>
                     <script async defer src="https://accounts.google.com/gsi/client" onload="gisLoaded()"></script>


### PR DESCRIPTION
## Summary
- add option to store Google Calendar ID
- pass calendar ID to admin auth script
- use configured calendar ID for GCal connection, availability checks, and booking event creation

## Testing
- `php -l includes/gcal.php`
- `php -l includes/settings.php`
- `node --check assets/gcal-auth.js && echo 'JS OK'`


------
https://chatgpt.com/codex/tasks/task_e_68a6b620991883208733b124b329950a